### PR TITLE
Custom rule labels

### DIFF
--- a/SpecExpress/.gitignore
+++ b/SpecExpress/.gitignore
@@ -1,0 +1,35 @@
+#ignore thumbnails created by windows
+Thumbs.db
+#Ignore files build by Visual Studio
+*.obj
+*.pdb
+*.user
+*.aps
+*.pch
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.suo
+*.tlb
+*.tlh
+*.bak
+*.cache
+*.ilk
+*.log
+[Bb]in
+[Dd]ebug*/
+*.lib
+*.sbr
+obj/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*
+deploy.config
+Examples*/
+*.vsmdi
+*.pidb
+*.userprefs
+*.testrunconfig
+publish.xml
+TestResults

--- a/SpecExpress/src/SpecExpress.Test/PropertyValidatorTests.cs
+++ b/SpecExpress/src/SpecExpress.Test/PropertyValidatorTests.cs
@@ -145,5 +145,21 @@ namespace SpecExpress.Test
             var actual = ValidationCatalog.SpecificationContainer.GetAllSpecifications().Single().PropertyValidators.Single().Label;
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void Validate_Property_Label_Is_Available_On_Error_When_Invalid()
+        {
+            const string expected = "This is a custom rule label";
+
+            ValidationCatalog.AddSpecification<Contact>(spec =>
+                spec.Check(c => c.FirstName).WithLabel(expected).Required());
+
+            var contact = new Contact();
+            var vn = ValidationCatalog.Validate(contact);
+            Assert.That(vn.IsValid, Is.False);
+
+            var error = vn.Errors.Single();
+            Assert.AreEqual(expected, error.Label);
+        }
     }
 }

--- a/SpecExpress/src/SpecExpress.Test/PropertyValidatorTests.cs
+++ b/SpecExpress/src/SpecExpress.Test/PropertyValidatorTests.cs
@@ -129,5 +129,21 @@ namespace SpecExpress.Test
             var vn = ValidationCatalog.Validate(new Contact());
             Assert.That(vn.IsValid, Is.True);
         }
+
+        [Test]
+        public void Validate_Property_With_CustomName_IsValid_And_Label_Is_Set()
+        {
+            const string expected = "This is a custom rule label";
+
+            ValidationCatalog.AddSpecification<Contact>(spec => 
+                spec.Check(c => c.FirstName).WithLabel(expected)
+                .If(c => String.IsNullOrEmpty(c.Addresses[0].City)).Required());
+
+            var vn = ValidationCatalog.Validate(new Contact());
+            Assert.That(vn.IsValid, Is.True);
+
+            var actual = ValidationCatalog.SpecificationContainer.GetAllSpecifications().Single().PropertyValidators.Single().Label;
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/SpecExpress/src/SpecExpress/DSL/ActionOptionConditionBuilder.cs
+++ b/SpecExpress/src/SpecExpress/DSL/ActionOptionConditionBuilder.cs
@@ -34,5 +34,16 @@ namespace SpecExpress.DSL
             return new ActionOptionBuilder<T, TProperty>(_propertyValidator);
         }
 
+        /// <summary>
+        /// Defines a custom "human-friendly" label for the validation rule.
+        /// The label can be located afterwards through <see cref="ValidationCatalog"/>'s <see cref="SpecificationContainer" />.
+        /// </summary>
+        /// <param name="labelName">The name for this custom label.</param>
+        /// <returns><see cref="ActionOptionConditionBuilder&lt;T, TProperty&gt;"/></returns>
+        public ActionOptionConditionBuilder<T, TProperty> WithLabel(string labelName)
+        {
+            _propertyValidator.Label = labelName;
+            return this;
+        }
     }
 }

--- a/SpecExpress/src/SpecExpress/PropertyValidator.cs
+++ b/SpecExpress/src/SpecExpress/PropertyValidator.cs
@@ -30,6 +30,7 @@ namespace SpecExpress
         public Type PropertyType { get; private set; }
         public Type EntityType { get; private set; }
         public SpecificationBase CustomSpecificationBase { get; set; }
+        public string Label { get; set; }
 
         public MemberInfo PropertyInfo
         {

--- a/SpecExpress/src/SpecExpress/PropertyValidator.cs
+++ b/SpecExpress/src/SpecExpress/PropertyValidator.cs
@@ -125,7 +125,7 @@ namespace SpecExpress
 
             try
             {
-                return Property.Compile().DynamicInvoke(new[] { instance });
+                return BuildPropertyDelegate().DynamicInvoke(new[] { instance });
             }
             catch (TargetInvocationException err)
             {
@@ -138,6 +138,12 @@ namespace SpecExpress
                     throw;
                 }
             }
+        }
+
+        private Delegate _propertyDelegate;
+        private Delegate BuildPropertyDelegate()
+        {
+            return _propertyDelegate ?? (_propertyDelegate = Property.Compile());
         }
 
         public RuleValidator RequiredRule { get; protected set; }

--- a/SpecExpress/src/SpecExpress/PropertyValidator.cs
+++ b/SpecExpress/src/SpecExpress/PropertyValidator.cs
@@ -486,6 +486,16 @@ namespace SpecExpress
                     }
                 }
             }
+
+            // Apply the validator label if there is one, to any errors
+            if(!string.IsNullOrWhiteSpace(Label))
+            {
+                foreach (var error in notification.Errors)
+                {
+                    error.Label = Label;
+                }
+            }
+            
             return notification.IsValid;
         }
 

--- a/SpecExpress/src/SpecExpress/Validates.cs
+++ b/SpecExpress/src/SpecExpress/Validates.cs
@@ -105,7 +105,7 @@ namespace SpecExpress
             lock (this)
             {
                 PropertyValidator<T, TProperty> validator = registerValidator(expression);
-
+                
 
                 validator.PropertyNameOverrideExpression = propertyNameOverride;
                 validator.Level = ValidationLevelType.Error;

--- a/SpecExpress/src/SpecExpress/ValidationResult.cs
+++ b/SpecExpress/src/SpecExpress/ValidationResult.cs
@@ -51,8 +51,9 @@ namespace SpecExpress
 
         public ValidationLevelType Level { get; protected set; }
         
-
         public IEnumerable<ValidationResult> NestedValidationResults {get;set;}
+
+        public string Label { get; set; }
 
         public IEnumerable<string> AllErrorMessages()
         {


### PR DESCRIPTION
Hey,

Where we're using this project, we need to be able to label each rule in a Validates<T> specification, so that we can display them in a human-readable way when we run them, store their results in a database, etc. After looking through the project I found what I thought was the best place to add this feature since the label would apply to the whole description of the rule vs. each rule that the 'Check' consists of. It's technically not a condition as the name of the class implies, but it "works" with the rest of the DSL and allows you to pair it with an "If" clause. I also added a standard .gitignore file as it appears you didn't have one.

Daniel
