### PR TITLE
Fixed bug in inline Specification

### DIFF
--- a/SpecExpress/src/SpecExpress.Test/Entities/Person.cs
+++ b/SpecExpress/src/SpecExpress.Test/Entities/Person.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpecExpress.Test.Entities
+{
+    public class Person
+    {
+        public string Name { get; set; }
+
+        public Address2 MailingAddress { get; set; }
+
+        public Address2 ShippingAddress { get; set; }
+    }
+    
+    public class Address2
+    {
+        public const string MailingType = "MAIL";
+
+        public const string ShippingType = "SHIP";
+
+        public string Type { get; set; }
+        public string AddressLine { get; set; }
+        public string City { get; set; }
+        public string State { get; set; }
+    }
+
+    public class PersonSpecification : Validates<Person>
+    {
+        public PersonSpecification()
+        {
+            Check(_ => _.Name).Required();
+
+            Check(_ => _.MailingAddress).Optional()
+                .Specification(v => v.Check(x => x.Type == Address2.MailingType))
+                .And
+                .Specification<Address2Specification>();
+
+            Check(_ => _.ShippingAddress).Optional()
+                .Specification(v => v.Check(x => x.Type == Address2.ShippingType))
+                .And
+                .Specification<Address2Specification>();
+        }
+    }
+
+    public class Address2Specification : Validates<Address2>
+    {
+        public Address2Specification()
+        {
+            Check(_ => _.AddressLine).Required();
+            Check(_ => _.City).Required();
+            Check(_ => _.State).Required();
+        }
+    }
+}

--- a/SpecExpress/src/SpecExpress.Test/PersonSpecificationTests.cs
+++ b/SpecExpress/src/SpecExpress.Test/PersonSpecificationTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using SpecExpress.Test.Entities;
+
+namespace SpecExpress.Test
+{
+    [TestFixture]
+    public class PersonSpecificationTests
+    {
+        [TestFixtureSetUp]
+        public void FixtureSetup()
+        {
+            ValidationCatalog.Reset();
+            ValidationCatalog.Scan(x => x.AddAssembly(typeof(Person).Assembly));
+            ValidationCatalog.AssertConfigurationIsValid();
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTeardown()
+        {
+            ValidationCatalog.Reset();
+        }
+
+        [Test]
+        public void Valid_Person()
+        {
+            var person = new Person()
+            {
+                Name = "Someone",
+                MailingAddress =
+                    new Address2()
+                    {
+                        AddressLine = "Dallas Pkwy",
+                        City = "Dallas",
+                        State = "TX",
+                        Type = Address2.MailingType
+                    },
+                ShippingAddress = 
+                    new Address2()
+                    {
+                        AddressLine = "Dallas Pkwy",
+                        City = "Dallas",
+                        State = "TX",
+                        Type = Address2.ShippingType
+                    },
+            };
+
+            var results = ValidationCatalog.Validate(person);
+            
+            Assert.That(results.IsValid, Is.True);
+
+            CollectionAssert.IsEmpty(results.All());
+        }
+
+        [Test]
+
+        public void Invalid_Person()
+        {
+            var person = new Person()
+            {
+                Name = "Someone",
+                MailingAddress =
+                    new Address2()
+                    {
+                        AddressLine = "Dallas Pkwy",
+                        City = "Dallas",
+                        State = "TX",
+                    },
+                ShippingAddress =
+                    new Address2()
+                    {
+                        //AddressLine = "Dallas Pkwy",
+                        //City = "Dallas",
+                        //State = "TX",
+                        Type = Address2.ShippingType
+                    },
+            };
+
+            var results = ValidationCatalog.Validate(person);
+            
+            foreach (var result in results.All())
+            {
+                Console.WriteLine(result.Message);
+            }
+
+            Assert.That(results.IsValid, Is.False);
+
+            CollectionAssert.IsNotEmpty(results.All());
+
+            
+             
+        }
+    }
+}

--- a/SpecExpress/src/SpecExpress.Test/SpecExpress.Test.csproj
+++ b/SpecExpress/src/SpecExpress.Test/SpecExpress.Test.csproj
@@ -91,8 +91,10 @@
     <Compile Include="Container\ComplexTypesTests.cs" />
     <Compile Include="ContactSpecification.cs" />
     <Compile Include="CustomerAddressSpecification.cs" />
+    <Compile Include="Entities\Person.cs" />
     <Compile Include="ExceptionsTest.cs" />
     <Compile Include="InlineSpecificationTests.cs" />
+    <Compile Include="PersonSpecificationTests.cs" />
     <Compile Include="PolymorphismTests.cs" />
     <Compile Include="RequiredEnumsTests.cs" />
     <Compile Include="RuleTreeTests\RuleExpressionFactoryTest.cs" />

--- a/SpecExpress/src/SpecExpress/Util/RuleValidatorContext.cs
+++ b/SpecExpress/src/SpecExpress/Util/RuleValidatorContext.cs
@@ -93,6 +93,12 @@ namespace SpecExpress.Rules
                 _propertyBag.Add(instanceType, new Dictionary<string, PropertyInfo>());
             }
             var propertyBag = _propertyBag[instanceType];
+
+            if (string.IsNullOrEmpty(validator.PropertyName))
+            {
+                return null;
+            }
+
             if (!propertyBag.ContainsKey(validator.PropertyName))
             {
                 propertyBag.Add(validator.PropertyName, instanceType.GetProperty(validator.PropertyName));
@@ -176,6 +182,12 @@ namespace SpecExpress.Rules
                 _propertyBag.Add(instanceType, new Dictionary<string, PropertyInfo>());
             }
             var propertyBag = _propertyBag[instanceType];
+
+            if (string.IsNullOrEmpty(validator.PropertyName))
+            {
+                return null;
+            }
+
             if (!propertyBag.ContainsKey(validator.PropertyName))
             {
                 propertyBag.Add(validator.PropertyName, instanceType.GetProperty(validator.PropertyName));


### PR DESCRIPTION
When creating Specification with inline specification. it throws ArgumentNullException.

```
public class Person
{
    public string Name { get; set; }

    public Address2 MailingAddress { get; set; }

    public Address2 ShippingAddress { get; set; }
}

public class Address2
{
    public const string MailingType = "MAIL";

    public const string ShippingType = "SHIP";

    public string Type { get; set; }
    public string AddressLine { get; set; }
    public string City { get; set; }
    public string State { get; set; }
}

public class PersonSpecification : Validates<Person>
{
    public PersonSpecification()
    {
        Check(_ => _.Name).Required();

        Check(_ => _.MailingAddress).Optional()
            .Specification(v => v.Check(x => x.Type == Address2.MailingType))
            .And
            .Specification<Address2Specification>();

        Check(_ => _.ShippingAddress).Optional()
            .Specification(v => v.Check(x => x.Type == Address2.ShippingType))
            .And
            .Specification<Address2Specification>();
    }
}

public class Address2Specification : Validates<Address2>
{
    public Address2Specification()
    {
        Check(_ => _.AddressLine).Required();
        Check(_ => _.City).Required();
        Check(_ => _.State).Required();
    }
}

```

that throws following error

```
System.ArgumentNullException : Value cannot be null.
Parameter name: key
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at SpecExpress.Rules.RuleValidatorContext.GetValidationProperty(PropertyValidator validator, Type instanceType) in RuleValidatorContext.cs: line 96
   at SpecExpress.Rules.RuleValidatorContext.SelectPropertyName(Object instance, PropertyValidator validator) in RuleValidatorContext.cs: line 55
   at SpecExpress.Rules.RuleValidatorContext..ctor(Object instance, PropertyValidator validator, RuleValidatorContext parentContext) in RuleValidatorContext.cs: line 36
   at SpecExpress.Rules.RuleValidatorContext`2..ctor(T instance, PropertyValidator`2 validator, RuleValidatorContext parentContext) in RuleValidatorContext.cs: line 114
   at SpecExpress.PropertyValidator`2.Validate(T instance, RuleValidatorContext parentRuleContext, SpecificationContainer specificationContainer, ValidationNotification notification) in PropertyValidator.cs: line 469
   at SpecExpress.PropertyValidator`1.Validate(Object instance, RuleValidatorContext parentRuleContext, SpecificationContainer specificationContainer, ValidationNotification notification) in PropertyValidator.cs: line 207
   at SpecExpress.Rules.GeneralValidators.SpecificationRule`2.Validate(RuleValidatorContext`2 context, SpecificationContainer specificationContainer, ValidationNotification notification) in SpecificationRule.cs: line 59
   at lambda_method(Closure, RuleValidatorContext`2, SpecificationContainer, ValidationNotification)
   at SpecExpress.PropertyValidator`2.Validate(T instance, RuleValidatorContext parentRuleContext, SpecificationContainer specificationContainer, ValidationNotification notification) in PropertyValidator.cs: line 477
   at SpecExpress.PropertyValidator`1.Validate(Object instance, SpecificationContainer specificationContainer, ValidationNotification notification) in PropertyValidator.cs: line 202
   at SpecExpress.SpecificationBase.Validate(Object instance, SpecificationContainer specificationContainer, ValidationNotification notification) in SpecificationBase.cs: line 34
   at SpecExpress.ValidationCatalog.Validate(Object instance, SpecificationContainer container, SpecificationBase specificationBase) in ValidationCatalog.cs: line 259
   at SpecExpress.ValidationCatalog.Validate(Object instance) in ValidationCatalog.cs: line 275
   at SpecExpress.Test.PersonSpecificationTests.Valid_Person() in PersonSpecificationTests.cs: line 44
```

Fixes are in the pull request.
